### PR TITLE
Default regexes disable bugfix bumps

### DIFF
--- a/src/test/scala/autoversion/model/CommitModelSpec.scala
+++ b/src/test/scala/autoversion/model/CommitModelSpec.scala
@@ -1,0 +1,23 @@
+package autoversion.model
+
+import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import sbtrelease.Version.Bump._
+
+class CommitModelSpec extends FlatSpec with Matchers with OptionValues {
+
+  val bugfixRegexes = List("""\[?bugfix\]?.*""", """\[?fix\]?.*""", """\[?patch\]?.*""").map(_.r)
+  val minorRegexes = List(".*").map(_.r)
+  val majorRegexes = List("""\[?breaking\]?.*""", """\[?major\]?.*""").map(_.r)
+
+  it should "be a major bump" in {
+    Commit("abcd1234", "[major] foo").suggestedBump(majorRegexes, minorRegexes, bugfixRegexes).value shouldEqual Major
+  }
+
+  it should "be a minor bump" in {
+    Commit("abcd1234", "whatever").suggestedBump(majorRegexes, minorRegexes, bugfixRegexes).value shouldEqual Minor
+  }
+
+  it should "be a bugfix bump" in {
+    Commit("abcd1234", "[bugfix]").suggestedBump(majorRegexes, minorRegexes, bugfixRegexes).value shouldEqual Bugfix
+  }
+}


### PR DESCRIPTION
I am running into this issue where the default bump regexes disable bugfix bumps entirely. The minor regex is set to `".*".r`, which will _always_ match the commit message. Then, in the `suggestedBump` method, any commit that matches minor takes precedence over any commit matching bugfix.

https://github.com/sbt/sbt-autoversion/blob/master/src/main/scala/autoversion/model/Commit.scala#L14-L25

This effectively disables bugfix bumps unless the regexes are changed in the project.

Is this how `suggestedBump` is intended to work?

It would be really useful to have a "default" bump such that if no commits matched any bump regex then the default would be used. Instead, a `RuntimeException` is thrown.

https://github.com/sbt/sbt-autoversion/blob/master/src/main/scala/autoversion/AutoVersionPlugin.scala#L55-L56

If this is not intended, I'd be happy to propose a fix.

-j