### PR TITLE
conventional commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk:
   - openjdk8
 
 script:
- - sbt ^test ^publishLocal
+ - sbt ^test ^scripted ^publishLocal
  - find $HOME/.sbt -name "*.lock" | xargs rm
  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
  - rm -Rf $HOME/.ivy2/cache/scala_2.10/sbt_0.13/org.scala-sbt/sbt-autoversion

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 The `sbt-autoversion` plugin builds on the [sbt-release](https://github.com/sbt/sbt-release) and [sbt-git](https://github.com/sbt/sbt-git) plugins to automatically manage the version bump to apply (major, minor or patch version bumps), based on commits messages patterns.
 
+## Highlights
+
+* Fully automatic releases
+  * Supports `release with-defaults`
+* Enforces [Semantic Versioning](https://semver.org/)
+* Uses [Conventional Commits](https://www.conventionalcommits.org/) to determine version bumps
+  * Configurable default behavior for unconventional commits
+
 ## Adding to your project
 
 Add the following line to your `project/plugins.sbt`:
@@ -24,28 +32,40 @@ Since `sbt-autoversion` is an `AutoPlugin`, it will be automatically available t
 * `autoVersionUnreleasedCommits`: lists commits since the latest tag/release
 * `autoVersionSuggestedBump`: shows what version bump the plugin has computed and would automatically apply on the next release.
 
+## Commits
+
+Commits should be structured as follows:
+```
+<type>[optional scope]: <description>
+
+[optional body]
+```
+
+See [Conventional Commits](https://www.conventionalcommits.org/) for more details.
+
 ## Settings
 
 #### `autoVersionTagNameCleaner`
 
 Linked to sbt-release's `releaseTagName` setting, defines how to "clean up" a Git tag to get back a semver-compatible version.
 
-#### `autoVersionMajorRegexes`, `autoVersionMinorRegexes`, `autoVersionBugfixRegexes`
+#### `autoVersionCommitConvention`
 
-The list of regular expression that a commit message should match to be seen as requiring respectively a major, a minor, or a bugfix version bump.
+Selects a version bump based on the "type" of commit (see: [Conventional Commits](https://www.conventionalcommits.org)).
 
-Default patterns:
+The following is the default convention:
+```scala
+case "major" | "breaking" => Some(Bump.Major)
+case "minor" | "feat" | "feature" => Some(Bump.Minor)
+case "fix" | "bugfix" | "patch" => Some(Bump.Bugfix)
+case _ => None
+```
 
-* major: `\[?breaking\]?.*`, `\[?major\]?.*`
-* minor: `\[?feature\]?.*`, `\[?minor\]?.*`
-* bugfix: `\[?bugfix\]?.*`, `\[?fix\]?.*`
-
-Note: regular expressions are executed in the order shown above (major, minor, then bugfix) and the first match is returned.
-See `autoVersionDefaultBump` for behavior if no matches are found in the unreleased commit messages.
+Any commit with `!` in the `<type>` or `BREAKING CHANGE` in the description is also interpreted as a major version bump.
 
 #### `autoVersionDefaultBump`
 
-If the plugin is unable to suggest a version bump based on commit messages (i.e., if none of the configured regular expressions match), this version bump will be suggested instead.
+If the plugin is unable to suggest a version bump based on commit messages, this version bump will be suggested instead.
 If set to `None`, an error will be thrown, and the release will be aborted.
 
 Set to `Some(Bump.Bugfix)` by default.

--- a/README.md
+++ b/README.md
@@ -33,13 +33,23 @@ Linked to sbt-release's `releaseTagName` setting, defines how to "clean up" a Gi
 
 #### `majorRegexes`, `minorRegexes`, `bugfixRegexes`
 
-The list of regular expression that a commit message should match to be seen as requiring respectively a major, a minor or a bugfix version bump (must match at least one pattern).
+The list of regular expression that a commit message should match to be seen as requiring respectively a major, a minor, or a bugfix version bump.
 
 Default patterns:
 
-* major: `\[?breaking\]?.*` `\[?major\]?.*`
-* minor: `.*`
+* major: `\[?breaking\]?.*`, `\[?major\]?.*`
+* minor: `\[?feature\]?.*`, `\[?minor\]?.*`
 * bugfix: `\[?bugfix\]?.*`, `\[?fix\]?.*`
+
+Note: regular expressions are executed in the order shown above (major, minor, then bugfix) and the first match is returned.
+See `defaultBump` for behavior if no matches are found in the unreleased commit messages.
+
+#### `defaultBump`
+
+If the plugin is unable to suggest a version bump based on commit messages (i.e., if none of the configured regular expressions match), this version bump will be suggested instead.
+If set to `None`, an error will be thrown, and the release will be aborted.
+
+Set to `Some(Bump.Bugfix)` by default.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Add the following line to your `project/plugins.sbt`:
 addSbtPlugin("org.scala-sbt" % "sbt-autoversion" % "1.0.0")
 ```
 
-Since `sbt-autoversion` is an AutoPlugin, it will be automatically available to your projects,
-given you're including both the [sbt-release](https://github.com/sbt/sbt-release) and [sbt-git](https://github.com/sbt/sbt-git) plugins.
+Since `sbt-autoversion` is an `AutoPlugin`, it will be automatically available to your projects.
 
 ## Usage
 
@@ -21,17 +20,17 @@ given you're including both the [sbt-release](https://github.com/sbt/sbt-release
 
 `sbt-autoversion` however expose a few interesting tasks:
 
-* `latestTag`: fetches the latest Git tag, based on Semantic Versioning ordering
-* `unreleasedCommits`: lists commits since the latest tag/release
-* `suggestedBump`: shows what version bump the plugin has computed and would automatically apply on the next release.
+* `autoVersionLatestTag`: fetches the latest Git tag, based on Semantic Versioning ordering
+* `autoVersionUnreleasedCommits`: lists commits since the latest tag/release
+* `autoVersionSuggestedBump`: shows what version bump the plugin has computed and would automatically apply on the next release.
 
 ## Settings
 
-#### `tagNameCleaner`
+#### `autoVersionTagNameCleaner`
 
 Linked to sbt-release's `releaseTagName` setting, defines how to "clean up" a Git tag to get back a semver-compatible version.
 
-#### `majorRegexes`, `minorRegexes`, `bugfixRegexes`
+#### `autoVersionMajorRegexes`, `autoVersionMinorRegexes`, `autoVersionBugfixRegexes`
 
 The list of regular expression that a commit message should match to be seen as requiring respectively a major, a minor, or a bugfix version bump.
 
@@ -42,9 +41,9 @@ Default patterns:
 * bugfix: `\[?bugfix\]?.*`, `\[?fix\]?.*`
 
 Note: regular expressions are executed in the order shown above (major, minor, then bugfix) and the first match is returned.
-See `defaultBump` for behavior if no matches are found in the unreleased commit messages.
+See `autoVersionDefaultBump` for behavior if no matches are found in the unreleased commit messages.
 
-#### `defaultBump`
+#### `autoVersionDefaultBump`
 
 If the plugin is unable to suggest a version bump based on commit messages (i.e., if none of the configured regular expressions match), this version bump will be suggested instead.
 If set to `None`, an error will be thrown, and the release will be aborted.

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 organization := "com.github.sbt"
 
-sbtPlugin := true
+enablePlugins(SbtPlugin)
+
 crossSbtVersions := Vector("0.13.18", "1.2.7")
 
 libraryDependencies += "com.vdurmont" % "semver4j" % "3.1.0"
@@ -9,7 +10,7 @@ libraryDependencies += "org.scalatest"  %% "scalatest"  % "3.0.9"  % "test"
 libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.3" % "test"
 
 // sbt plugin dependencies
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"     % "1.0.0")
 
 scalacOptions := Seq(
@@ -22,3 +23,6 @@ scalacOptions := Seq(
 )
 
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
+
+scriptedBufferLog := false
+scriptedLaunchOpts ++= Seq("-Xmx1024M", "-server", "-Dplugin.version=" + version.value)

--- a/src/main/scala/autoversion/AutoVersion.scala
+++ b/src/main/scala/autoversion/AutoVersion.scala
@@ -1,0 +1,19 @@
+package autoversion
+
+import sbtrelease.Version.Bump
+import sbtrelease.{Version, versionFormatError}
+
+object AutoVersion {
+
+  def setReleaseVersion(bump: Bump): String => String = { (ver: String) =>
+    val bugfixSuggested = bump == Bump.Bugfix
+
+    // If the previous version is a snapshot (qualified) and a bugfix is recommended, simply drop the qualifier.
+    // Otherwise the expected bugfix version will be skipped.
+    // e.g. 0.1.4 => 0.1.5-SNAPSHOT => 0.1.5
+    Version(ver).map {
+      case v if v.qualifier.isDefined && bugfixSuggested => v.withoutQualifier.string
+      case v => v.bump(bump).withoutQualifier.string
+    }.getOrElse(versionFormatError(ver))
+  }
+}

--- a/src/main/scala/autoversion/AutoVersionPlugin.scala
+++ b/src/main/scala/autoversion/AutoVersionPlugin.scala
@@ -1,14 +1,14 @@
 package autoversion
 
-import autoversion.model.{Commit, Tag}
 import autoversion.model.BumpOrdering.bumpOrdering
-
-import sbt._
+import autoversion.model.{Commit, Tag}
 import com.typesafe.sbt.{GitPlugin, SbtGit}
 import com.vdurmont.semver4j.Semver
 import com.vdurmont.semver4j.Semver.SemverType
-import sbtrelease.{versionFormatError, ReleasePlugin, Version}
+import sbt._
+import sbtrelease.ReleasePlugin
 import sbtrelease.ReleasePlugin.autoImport.releaseVersion
+import sbtrelease.Version.Bump
 
 import scala.util.Properties
 
@@ -19,23 +19,23 @@ object AutoVersionPlugin extends AutoPlugin {
   import autoImport._
 
   override def trigger: PluginTrigger = allRequirements
-  override def requires: Plugins      = GitPlugin && ReleasePlugin
+
+  override def requires: Plugins = GitPlugin && ReleasePlugin
 
   override def projectSettings: Seq[Setting[_]] = Seq(
     tagNameCleaner := { _.stripPrefix("v") },
-    bugfixRegexes := List("""\[?bugfix\]?.*""", """\[?fix\]?.*""", """\[?patch\]?.*""").map(_.r),
-    minorRegexes := List(".*").map(_.r),
+    bugfixRegexes := List("""\[?(bug)?fix\]?.*""", """\[?patch\]?.*""").map(_.r),
+    minorRegexes := List("""\[?feature\]?.*""", """\[?minor\]?.*""").map(_.r),
     majorRegexes := List("""\[?breaking\]?.*""", """\[?major\]?.*""").map(_.r),
     latestTag := findLatestTag.value,
     unreleasedCommits := listUnreleasedCommits.value,
     suggestedBump := suggestBump.value,
-    releaseVersion := { ver =>
-      Version(ver).map(v => v.bump(suggestedBump.value).withoutQualifier.string).getOrElse(versionFormatError)
-    }
+    releaseVersion := AutoVersion.setReleaseVersion(suggestedBump.value),
+    defaultBump := Some(Bump.Bugfix)
   )
 
   private lazy val findLatestTag = Def.task {
-    val gitTags  = runGit("tag", "--list").value
+    val gitTags = runGit("tag", "--list").value
     val versions = gitTags.map(tag => Tag(tag, new Semver(tagNameCleaner.value(tag), SemverType.LOOSE)))
     versions.sortBy(_.version).lastOption
   }
@@ -49,12 +49,23 @@ object AutoVersionPlugin extends AutoPlugin {
   }
 
   private lazy val suggestBump = Def.task {
-    val commits = unreleasedCommits.value
-    val suggestedBumps =
+    val log = sbt.Keys.streams.value.log
+    val default = defaultBump.value
+    val suggestedBumps = {
+      val commits = unreleasedCommits.value
       commits.flatMap(_.suggestedBump(majorRegexes.value, minorRegexes.value, bugfixRegexes.value))
-    if (suggestedBumps.isEmpty)
-      throw new RuntimeException("No commit matches either patterns for bugfix, minor or major bumps !")
-    else suggestedBumps.max
+    }
+
+    if (suggestedBumps.nonEmpty) suggestedBumps.max
+    else default match {
+      case None => sys.error("No commit matches either patterns for bugfix, minor or major bumps !")
+      case Some(bump) =>
+        log.warn(
+          "Unreleased commits did not match any configured sbt-autoversion regular expression. " +
+            s"Defaulting to '${bump.toString}'."
+        )
+        bump
+    }
   }
 
   private def runGit(args: String*) = Def.task {

--- a/src/main/scala/autoversion/Keys.scala
+++ b/src/main/scala/autoversion/Keys.scala
@@ -1,18 +1,14 @@
 package autoversion
 
-import autoversion.model.{Commit, Tag}
+import autoversion.model.{Commit, ConventionalCommit, Tag}
 import sbt.{settingKey, taskKey}
 import sbtrelease.Version.Bump
-
-import scala.util.matching.Regex
 
 object Keys {
   val autoVersionLatestTag         = taskKey[Option[Tag]]("Latest semver version from Git tags.")
   val autoVersionTagNameCleaner    = settingKey[String => String]("Cleans the git tag to extract only the version.")
   val autoVersionUnreleasedCommits = taskKey[Seq[Commit]]("Commits since the latest tagged release.")
   val autoVersionSuggestedBump     = taskKey[Bump]("Version bump computed by sbt-autoversion")
-  val autoVersionBugfixRegexes     = settingKey[Seq[Regex]]("Regex that commit messages must follow to use a bugfix bump.")
-  val autoVersionMinorRegexes      = settingKey[Seq[Regex]]("Regex that commit messages must follow to use a minor bump.")
-  val autoVersionMajorRegexes      = settingKey[Seq[Regex]]("Regex that commit messages must follow to use a major bump.")
+  val autoVersionCommitConvention  = settingKey[String => Option[Bump]]("Map allowed commit types to their expected version bump.")
   val autoVersionDefaultBump       = settingKey[Option[Bump]]("Default version bump if sbt-autoversion is unable to suggest one based on commit messages.")
 }

--- a/src/main/scala/autoversion/Keys.scala
+++ b/src/main/scala/autoversion/Keys.scala
@@ -7,12 +7,12 @@ import sbtrelease.Version.Bump
 import scala.util.matching.Regex
 
 object Keys {
-  val latestTag         = taskKey[Option[Tag]]("Latest semver version from Git tags.")
-  val tagNameCleaner    = settingKey[String => String]("Cleans the git tag to extract only the version.")
-  val unreleasedCommits = taskKey[Seq[Commit]]("Commits since the latest tagged release.")
-  val suggestedBump     = taskKey[Bump]("Version bump computed by sbt-autoversion")
-  val bugfixRegexes     = settingKey[Seq[Regex]]("Regex that commit messages must follow to use a bugfix bump.")
-  val minorRegexes      = settingKey[Seq[Regex]]("Regex that commit messages must follow to use a minor bump.")
-  val majorRegexes      = settingKey[Seq[Regex]]("Regex that commit messages must follow to use a major bump.")
-  val defaultBump       = settingKey[Option[Bump]]("Default version bump if sbt-autoversion is unable to suggest one based on commit messages.")
+  val autoVersionLatestTag         = taskKey[Option[Tag]]("Latest semver version from Git tags.")
+  val autoVersionTagNameCleaner    = settingKey[String => String]("Cleans the git tag to extract only the version.")
+  val autoVersionUnreleasedCommits = taskKey[Seq[Commit]]("Commits since the latest tagged release.")
+  val autoVersionSuggestedBump     = taskKey[Bump]("Version bump computed by sbt-autoversion")
+  val autoVersionBugfixRegexes     = settingKey[Seq[Regex]]("Regex that commit messages must follow to use a bugfix bump.")
+  val autoVersionMinorRegexes      = settingKey[Seq[Regex]]("Regex that commit messages must follow to use a minor bump.")
+  val autoVersionMajorRegexes      = settingKey[Seq[Regex]]("Regex that commit messages must follow to use a major bump.")
+  val autoVersionDefaultBump       = settingKey[Option[Bump]]("Default version bump if sbt-autoversion is unable to suggest one based on commit messages.")
 }

--- a/src/main/scala/autoversion/Keys.scala
+++ b/src/main/scala/autoversion/Keys.scala
@@ -14,4 +14,5 @@ object Keys {
   val bugfixRegexes     = settingKey[Seq[Regex]]("Regex that commit messages must follow to use a bugfix bump.")
   val minorRegexes      = settingKey[Seq[Regex]]("Regex that commit messages must follow to use a minor bump.")
   val majorRegexes      = settingKey[Seq[Regex]]("Regex that commit messages must follow to use a major bump.")
+  val defaultBump       = settingKey[Option[Bump]]("Default version bump if sbt-autoversion is unable to suggest one based on commit messages.")
 }

--- a/src/main/scala/autoversion/model/Commit.scala
+++ b/src/main/scala/autoversion/model/Commit.scala
@@ -1,30 +1,11 @@
 package autoversion.model
 
-import sbtrelease.Version.Bump
-
-import scala.util.matching.Regex
+case class Commit(sha: String, msg: String)
 
 object Commit {
+
   def apply(commitLine: String): Commit = {
     def parts = commitLine.split(" ")
     Commit(parts(0), parts.drop(1).mkString(" "))
   }
-}
-case class Commit(sha: String, msg: String) {
-  def suggestedBump(majorRegexes: Seq[Regex], minorRegexes: Seq[Regex], bugfixRegexes: Seq[Regex]): Option[Bump] = {
-    val majorSuggested = majorRegexes.exists(r => matches(r, msg))
-    if (majorSuggested) Some(Bump.Major)
-    else {
-      val minorSuggested = minorRegexes.exists(r => matches(r, msg))
-      if (minorSuggested) Some(Bump.Minor)
-      else {
-        val bugfixSuggested = bugfixRegexes.exists(r => matches(r, msg))
-        if (bugfixSuggested) Some(Bump.Bugfix)
-        else None
-      }
-    }
-  }
-
-  private def matches(regex: Regex, s: String): Boolean =
-    regex.pattern.matcher(s).matches
 }

--- a/src/main/scala/autoversion/model/ConventionalCommit.scala
+++ b/src/main/scala/autoversion/model/ConventionalCommit.scala
@@ -1,0 +1,32 @@
+package autoversion.model
+
+case class ConventionalCommit(
+  commitMessage: String,
+  kind: String,
+  breaking: Boolean = false,
+  scope: Option[String] = None,
+  description: Option[String] = None
+)
+
+object ConventionalCommit {
+
+  def parse(message: String): Option[ConventionalCommit] = {
+    val pattern = """^(?<kind>[\w\s]+)\s*(\((?<scope>[\w\s]+)\))?\s*(?<breaking>!)?\s*:\s+(?<description>.+)$"""
+    val regex = pattern.r("kind", "outerscope", "scope", "breaking", "description")
+
+    regex.findFirstMatchIn(message).flatMap { m =>
+      val breaking = Option(m.group("breaking")).isDefined || message.contains("BREAKING CHANGE")
+
+      for {
+        kind <- Option(m.group("kind"))
+      } yield ConventionalCommit(
+        commitMessage = message,
+        kind = kind.trim.toLowerCase,
+        breaking = breaking,
+        scope = Option(m.group("scope")).map(_.trim.toLowerCase),
+        description = Option(m.group("description")).map(_.trim)
+      )
+    }
+  }
+
+}

--- a/src/sbt-test/sbt-autoversion/simple/.gitignore
+++ b/src/sbt-test/sbt-autoversion/simple/.gitignore
@@ -1,0 +1,2 @@
+target
+global

--- a/src/sbt-test/sbt-autoversion/simple/build.sbt
+++ b/src/sbt-test/sbt-autoversion/simple/build.sbt
@@ -1,0 +1,16 @@
+import ReleaseTransformations._
+
+// Default sbt-release process, minus publication (for testing).
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  // publishArtifacts,
+  setNextVersion,
+  commitNextVersion
+  // pushChanges
+)

--- a/src/sbt-test/sbt-autoversion/simple/project/plugins.sbt
+++ b/src/sbt-test/sbt-autoversion/simple/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-autoversion" % System.getProperty("plugin.version"))

--- a/src/sbt-test/sbt-autoversion/simple/test
+++ b/src/sbt-test/sbt-autoversion/simple/test
@@ -1,0 +1,104 @@
+# Generate project files.
+> reload
+> compile
+
+# Setup repository.
+$ exec git init
+$ exec git add .
+$ exec git commit -m 'initial commit'
+$ exec git tag v0.0.0
+
+# Prove sbt can start.
+> reload
+> compile
+> show version
+
+# 0.0.0 => 0.0.1 => 0.0.2-SNAPSHOT
+$ exec git commit --allow-empty -m 'fix: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"0.0.2-SNAPSHOT"' version.sbt
+
+# 0.0.2-SNAPSHOT => 0.0.2 => 0.0.3-SNAPSHOT
+$ exec git commit --allow-empty -m 'bugfix: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"0.0.3-SNAPSHOT"' version.sbt
+
+# 0.0.3-SNAPSHOT => 0.0.3 => 0.0.4-SNAPSHOT
+$ exec git commit --allow-empty -m 'patch: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"0.0.4-SNAPSHOT"' version.sbt
+
+# 0.0.4-SNAPSHOT => 0.1.0 => 0.1.1-SNAPSHOT
+$ exec git commit --allow-empty -m 'feature: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"0.1.1-SNAPSHOT"' version.sbt
+
+# 0.1.1-SNAPSHOT => 0.1.1 => 0.1.2-SNAPSHOT
+$ exec git commit --allow-empty -m '[fix]: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"0.1.2-SNAPSHOT"' version.sbt
+
+# 0.1.2-SNAPSHOT => 0.1.2 => 0.1.3-SNAPSHOT
+$ exec git commit --allow-empty -m '[bugfix]: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"0.1.3-SNAPSHOT"' version.sbt
+
+# 0.1.3-SNAPSHOT => 0.2.0 => 0.2.1-SNAPSHOT
+$ exec git commit --allow-empty -m '[minor]: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"0.2.1-SNAPSHOT"' version.sbt
+
+# 0.2.1-SNAPSHOT => 0.3.0 => 0.3.1-SNAPSHOT
+$ exec git commit --allow-empty -m '[feature]: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"0.3.1-SNAPSHOT"' version.sbt
+
+# 0.3.1-SNAPSHOT => 1.0.0 => 1.0.1-SNAPSHOT
+$ exec git commit --allow-empty -m '[major]: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"1.0.1-SNAPSHOT"' version.sbt
+
+# 1.0.1-SNAPSHOT => 1.0.1 => 1.0.2-SNAPSHOT
+$ exec git commit --allow-empty -m '[fix]: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"1.0.2-SNAPSHOT"' version.sbt
+
+# 1.0.2-SNAPSHOT => 1.0.2 => 1.0.3-SNAPSHOT
+$ exec git commit --allow-empty -m 'patch: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"1.0.3-SNAPSHOT"' version.sbt
+
+# 1.0.3-SNAPSHOT => 1.1.0 => 1.1.1-SNAPSHOT
+$ exec git commit --allow-empty -m 'feature: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"1.1.1-SNAPSHOT"' version.sbt
+
+# 1.1.1-SNAPSHOT => 1.2.0 => 1.2.1-SNAPSHOT
+$ exec git commit --allow-empty -m 'minor: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"1.2.1-SNAPSHOT"' version.sbt
+
+# 1.2.1-SNAPSHOT => 2.0.0 => 2.0.1-SNAPSHOT
+$ exec git commit --allow-empty -m '[breaking]: foobar'
+> reload
+> release with-defaults
+$ exec grep -Fq '"2.0.1-SNAPSHOT"' version.sbt
+
+# 2.0.1-SNAPSHOT => 2.0.1 => 2.0.2-SNAPSHOT
+$ exec git commit --allow-empty -m 'doing hard work'
+> reload
+> release with-defaults
+$ exec grep -Fq '"2.0.2-SNAPSHOT"' version.sbt

--- a/src/sbt-test/sbt-autoversion/simple/test
+++ b/src/sbt-test/sbt-autoversion/simple/test
@@ -38,43 +38,43 @@ $ exec git commit --allow-empty -m 'feature: foobar'
 $ exec grep -Fq '"0.1.1-SNAPSHOT"' version.sbt
 
 # 0.1.1-SNAPSHOT => 0.1.1 => 0.1.2-SNAPSHOT
-$ exec git commit --allow-empty -m '[fix]: foobar'
+$ exec git commit --allow-empty -m 'fix(issues): foobar'
 > reload
 > release with-defaults
 $ exec grep -Fq '"0.1.2-SNAPSHOT"' version.sbt
 
 # 0.1.2-SNAPSHOT => 0.1.2 => 0.1.3-SNAPSHOT
-$ exec git commit --allow-empty -m '[bugfix]: foobar'
+$ exec git commit --allow-empty -m 'bugfix(service 2): foobar'
 > reload
 > release with-defaults
 $ exec grep -Fq '"0.1.3-SNAPSHOT"' version.sbt
 
 # 0.1.3-SNAPSHOT => 0.2.0 => 0.2.1-SNAPSHOT
-$ exec git commit --allow-empty -m '[minor]: foobar'
+$ exec git commit --allow-empty -m 'minor(issue 13): foobar'
 > reload
 > release with-defaults
 $ exec grep -Fq '"0.2.1-SNAPSHOT"' version.sbt
 
 # 0.2.1-SNAPSHOT => 0.3.0 => 0.3.1-SNAPSHOT
-$ exec git commit --allow-empty -m '[feature]: foobar'
+$ exec git commit --allow-empty -m 'feature: foobar'
 > reload
 > release with-defaults
 $ exec grep -Fq '"0.3.1-SNAPSHOT"' version.sbt
 
 # 0.3.1-SNAPSHOT => 1.0.0 => 1.0.1-SNAPSHOT
-$ exec git commit --allow-empty -m '[major]: foobar'
+$ exec git commit --allow-empty -m 'refactor: BREAKING CHANGE'
 > reload
 > release with-defaults
 $ exec grep -Fq '"1.0.1-SNAPSHOT"' version.sbt
 
 # 1.0.1-SNAPSHOT => 1.0.1 => 1.0.2-SNAPSHOT
-$ exec git commit --allow-empty -m '[fix]: foobar'
+$ exec git commit --allow-empty -m 'fix: foobar'
 > reload
 > release with-defaults
 $ exec grep -Fq '"1.0.2-SNAPSHOT"' version.sbt
 
 # 1.0.2-SNAPSHOT => 1.0.2 => 1.0.3-SNAPSHOT
-$ exec git commit --allow-empty -m 'patch: foobar'
+$ exec git commit --allow-empty -m 'maintenance(docs): foobar'
 > reload
 > release with-defaults
 $ exec grep -Fq '"1.0.3-SNAPSHOT"' version.sbt
@@ -92,7 +92,7 @@ $ exec git commit --allow-empty -m 'minor: foobar'
 $ exec grep -Fq '"1.2.1-SNAPSHOT"' version.sbt
 
 # 1.2.1-SNAPSHOT => 2.0.0 => 2.0.1-SNAPSHOT
-$ exec git commit --allow-empty -m '[breaking]: foobar'
+$ exec git commit --allow-empty -m 'refactor!: foobar'
 > reload
 > release with-defaults
 $ exec grep -Fq '"2.0.1-SNAPSHOT"' version.sbt

--- a/src/sbt-test/sbt-autoversion/simple/version.sbt
+++ b/src/sbt-test/sbt-autoversion/simple/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.0.0"

--- a/src/test/scala/autoversion/AutoVersionSpec.scala
+++ b/src/test/scala/autoversion/AutoVersionSpec.scala
@@ -1,0 +1,61 @@
+package autoversion
+
+import org.scalatest.{FreeSpec, Matchers}
+import sbtrelease.Version.Bump
+import sbtrelease.{Version, versionFormatError}
+
+class AutoVersionSpec extends FreeSpec with Matchers {
+
+  private def autoVersion(raw: String, bump: Bump): String = {
+    val version = Version(raw).getOrElse(versionFormatError(raw))
+    AutoVersion.setReleaseVersion(bump)(version.string)
+  }
+
+  "qualified patch release" - {
+    val version = "3.9.18-SNAPSHOT"
+
+    "patch: drop the qualifier" in {
+      autoVersion(version, Bump.Bugfix) shouldEqual "3.9.18"
+    }
+
+    "minor: proceed to next minor" in {
+      autoVersion(version, Bump.Minor) shouldEqual "3.10.0"
+    }
+
+    "major: proceed to next major" in {
+      autoVersion(version, Bump.Major) shouldEqual "4.0.0"
+    }
+  }
+
+  "unqualified patch release" - {
+    val version = "3.9.18"
+
+    "patch: proceed to next patch" in {
+      autoVersion(version, Bump.Bugfix) shouldEqual "3.9.19"
+    }
+
+    "minor: proceed to next minor" in {
+      autoVersion(version, Bump.Minor) shouldEqual "3.10.0"
+    }
+
+    "major: proceed to next major" in {
+      autoVersion(version, Bump.Major) shouldEqual "4.0.0"
+    }
+  }
+
+  "overly precise version" - {
+    val version = "3.9.18.4.12"
+
+    "patch: proceed to next patch" in {
+      autoVersion(version, Bump.Bugfix) shouldEqual "3.9.19.0.0"
+    }
+
+    "minor: proceed to next minor" in {
+      autoVersion(version, Bump.Minor) shouldEqual "3.10.0.0.0"
+    }
+
+    "major: proceed to next major" in {
+      autoVersion(version, Bump.Major) shouldEqual "4.0.0.0.0"
+    }
+  }
+}

--- a/src/test/scala/autoversion/model/ConventionalCommitSpec.scala
+++ b/src/test/scala/autoversion/model/ConventionalCommitSpec.scala
@@ -1,0 +1,63 @@
+package autoversion.model
+
+import org.scalatest.{FreeSpec, Matchers, OptionValues}
+
+class ConventionalCommitSpec extends FreeSpec with Matchers with OptionValues {
+
+  "unconventional commits" in {
+    ConventionalCommit.parse("committed the thing to fix the other thing") shouldBe empty
+    ConventionalCommit.parse("working on branch B") shouldBe empty
+    ConventionalCommit.parse("fix stupidity") shouldBe empty
+    ConventionalCommit.parse("asdf") shouldBe empty
+    ConventionalCommit.parse("lorem ipsum dolor sit amet") shouldBe empty
+    ConventionalCommit.parse("fix: ") shouldBe empty
+    ConventionalCommit.parse(": foo") shouldBe empty
+    ConventionalCommit.parse("(bar): foo") shouldBe empty
+    ConventionalCommit.parse("(foo):") shouldBe empty
+    ConventionalCommit.parse("(foo)") shouldBe empty
+    ConventionalCommit.parse("") shouldBe empty
+  }
+
+  "conventional commits" - {
+
+    "without scope" in {
+      val commit = ConventionalCommit.parse("fix: do work").value
+      commit.kind shouldEqual "fix"
+      commit.breaking shouldBe false
+      commit.scope shouldBe empty
+      commit.description.value shouldEqual "do work"
+    }
+
+    "with scope" in {
+      val commit = ConventionalCommit.parse("fix(services): do work").value
+      commit.kind shouldEqual "fix"
+      commit.breaking shouldBe false
+      commit.scope.value shouldEqual "services"
+      commit.description.value shouldEqual "do work"
+    }
+
+    "with multiword scope" in {
+      val commit = ConventionalCommit.parse("fix(important 123 services): do work").value
+      commit.kind shouldEqual "fix"
+      commit.breaking shouldBe false
+      commit.scope.value shouldEqual "important 123 services"
+      commit.description.value shouldEqual "do work"
+    }
+
+    "with breaking flag" in {
+      val commit = ConventionalCommit.parse("break(everything)!: oh no").value
+      commit.kind shouldEqual "break"
+      commit.breaking shouldBe true
+      commit.scope.value shouldEqual "everything"
+      commit.description.value shouldEqual "oh no"
+    }
+
+    "with BREAKING CHANGE in body" in {
+      val commit = ConventionalCommit.parse("docs: introduce a BREAKING CHANGE").value
+      commit.kind shouldEqual "docs"
+      commit.breaking shouldBe true
+      commit.scope shouldBe empty
+      commit.description.value shouldEqual "introduce a BREAKING CHANGE"
+    }
+  }
+}


### PR DESCRIPTION
This is a pretty big rewrite and significantly changes the nature of the plugin. I'm interested in your take on this approach.

If you don't like it for mainline `sbt-autoversion`, it could certainly also be moved into a sibling subproject/artifact, or even an entirely new repo (e.g. `sbt-conventional-commits`). Let me know what you think.

Basically this implements [Conventional Commits](https://www.conventionalcommits.org) for `sbt`.

The particulars of the "convention" are a function `String => Option[Version.Bump]`. It's powered by a simple regex parser that extracts commit `type` which is fed into the convention.

Right now, most of the `ConventionalCommit` model are not being used. Only the `type` is used for auto-versioning. But you could probably do more with the details of each commit in the future.

This PR is also stacked on top of https://github.com/sbt/sbt-autoversion/pull/90. The first commit is that PR.

fyi @pdalpra 