### PR TITLE
Reachable aware latestTag

### DIFF
--- a/src/main/scala/autoversion/AutoVersionPlugin.scala
+++ b/src/main/scala/autoversion/AutoVersionPlugin.scala
@@ -36,9 +36,14 @@ object AutoVersionPlugin extends AutoPlugin {
     )
 
   private lazy val findLatestTag = Def.task {
-    val gitTags  = runGit("tag", "--list").value
-    val versions = gitTags.map(tag => Tag(tag, new Semver(tagNameCleaner.value(tag), SemverType.LOOSE)))
-    versions.sortBy(_.version).lastOption
+    // uses git describe to find the closest reachable tag belonging to the tree of current HEAD with a prefix of 'v'
+    runGit("describe", "--abbrev=0", "--always", "--match=v*")
+      .value
+      .filter(_.startsWith("v"))
+      .map(tag => {
+        Tag(tag, new Semver(tagNameCleaner.value(tag), SemverType.LOOSE))
+      })
+      .headOption
   }
 
   private lazy val listUnreleasedCommits = Def.taskDyn {

--- a/src/sbt-test/sbt-autoversion/simple/test
+++ b/src/sbt-test/sbt-autoversion/simple/test
@@ -95,3 +95,21 @@ $ exec git commit --allow-empty -m 'doing hard work'
 > reload
 > release with-defaults
 $ exec grep -Fq '"2.0.2-SNAPSHOT"' version.sbt
+
+# Reachable latestTag cases
+# create some unreleased commits on master
+$ exec git commit --allow-empty -m '[feat]: new features'
+$ exec git commit --allow-empty -m '[breaking]: breaking new features for better features'
+
+# Create release/maintenance branch 0.2.x
+$ exec git branch 0.2.x v0.2.0
+# 0.2.1-SNAPSHOT => 0.2.1 => 0.2.2-SNAPSHOT
+$ exec git checkout 0.2.x
+$ exec git tag release3-tag -a -m "Tag marking v0.2.0 as release 3"
+$ exec git commit --allow-empty -m 'doing more work'
+$ exec git tag different-tag -a -m "some intermediate tag"
+$ exec git commit --allow-empty -m '[fix]: fixing bugs'
+$ exec grep -Fq '"0.2.0"' version.sbt
+> reload
+> release with-defaults
+$ exec grep -Fq '"0.2.2-SNAPSHOT"' version.sbt


### PR DESCRIPTION
For consideration.  Addresses #107.  Makes `latestTag` context dependent (ie 'reachable') rather than repo-wide, which I suppose could be considered a breaking change.  In primary use-cases (ie standard `master` trunk-based development), the behaviour will likely remain the same.  