### PR TITLE
Use full commit message instead of --oneline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 .bsp
 .vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ If set to `None`, an error will be thrown, and the release will be aborted.
 
 Set to `Some(Bump.Bugfix)` by default.
 
+#### `unreleasedCommits`
+
+By default, `git log --oneline` is used to list the unreleased commits and match them against the regexes. If you need
+the full commit text (e.g. to search for scala-steward semver labels), you can use
+* `unreleasedCommits := AutoVersionPlugin.listUnreleasedCommitsLong.value`
+
 # License
 
 This software is under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).


### PR DESCRIPTION
This helps to use autoversion in combination with scala steward.
Major library updates can then result in major version updates,
which helps escaping dependency hell.