### PR TITLE
chore:  Minor updates:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.20]
-        java: [zulu@8, temurin@11, temurin@17]
+        java: [zulu@8, temurin@11, temurin@17, temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -54,6 +54,14 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+          cache: sbt
+
+      - name: Setup Java (temurin@21)
+        if: matrix.java == 'temurin@21'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
           cache: sbt
 
       - name: Setup sbt
@@ -111,6 +119,14 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+          cache: sbt
+
+      - name: Setup Java (temurin@21)
+        if: matrix.java == 'temurin@21'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
           cache: sbt
 
       - name: Setup sbt

--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ _Note_:  By default these patterns are applied _in addition_ to the default patt
 conventionalPatternsAdditive := false
 ```
 
-# License
+## Maintenance
+
+### CI
+This project uses the [sbt-ci-release](https://github.com/sbt/sbt-ci-release) for generating GitHub actions in the `.github` actions directory, based on declared build configuration in `github-actions.sbt`. 
+
+When making changes to `github-actions.sbt` job declarations, the Github actions should be updated to reflect these changes by running the following task:
+
+```
+sbt githubWorkflowGenerate
+```
+
+### Releasing
+
+To release a new version of this plugin simply create a new tag against the intended release commit which should trigger the `release` Gitbhub action. 
+
+
+## License
 
 This software is under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Release](https://github.com/sbt/sbt-autoversion/actions/workflows/release.yml/badge.svg)](https://github.com/sbt/sbt-autoversion/actions/workflows/release.yml)
+[![CI](https://github.com/sbt/sbt-autoversion/actions/workflows/ci.yml/badge.svg)](https://github.com/sbt/sbt-autoversion/actions/workflows/ci.yml)
+[![Latest version](https://img.shields.io/github/tag/sbt/sbt-autoversion.svg)](https://github.com/sbt/sbt-autoversion/releases)
+
 # sbt-autoversion
 
 The `sbt-autoversion` plugin builds on the [sbt-release](https://github.com/sbt/sbt-release) and [sbt-git](https://github.com/sbt/sbt-git) plugins to automatically manage the version bump to apply (major, minor or patch version bumps), based on commits messages patterns.

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ libraryDependencies ++= Seq(
   "com.vdurmont"       % "semver4j"        % "3.1.0",
   "org.scalatest"     %% "scalatest"       % "3.2.19"   % Test,
   "org.scalacheck"    %% "scalacheck"      % "1.18.1"   % Test,
-  "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % Test
+  "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % Test
 )
 
 // sbt plugin dependencies

--- a/github-actions.sbt
+++ b/github-actions.sbt
@@ -1,6 +1,6 @@
 inThisBuild(
   Seq(
-    githubWorkflowJavaVersions ++= Seq(JavaSpec.temurin("11"), JavaSpec.temurin("17")),
+    githubWorkflowJavaVersions ++= Seq(JavaSpec.temurin("11"), JavaSpec.temurin("17"), JavaSpec.temurin("21")),
     githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test", "scripted"))),
     githubWorkflowTargetTags ++= Seq("v*"),
     githubWorkflowPublishTargetBranches += RefPredicate.StartsWith(Ref.Tag("v")),


### PR DESCRIPTION
- Update to latest Scalatestplus version embedded in the artifact ID, which Scala Steward is unable to recognize
- Adding JDK21 support to the build actions
- Adding a small maintenance section to the readme describing the process used for maintaining CI jobs and cutting a release
- Adding status badges to the README